### PR TITLE
【Fixed】Issue#48　カスタマーが配送先の住所を注文時に選択できるように修正

### DIFF
--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -25,12 +25,10 @@ class CartsController < ApplicationController
       :currency => 'jpy'
     )
 
-    @address = @user.addresses.first
-
     @order = Order.create(
       user_id: @user.id,
       price: params[:cart][:total_price],
-      # shipping_to:
+      shipping_to: params[:cart][:address_id]
     )
 
     @carts.each do |item|
@@ -63,7 +61,7 @@ class CartsController < ApplicationController
   end
 
   def cart_params
-    params.require(:cart).permit(:checkbox, address_id:[])
+    params.require(:cart).permit(:address_id)
   end
 
 end

--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -32,10 +32,19 @@ class CartsController < ApplicationController
       :currency => 'jpy'
     )
 
+    @address = Address.find(params[:cart][:address_id])
+
     @order = Order.create(
       user_id: @user.id,
       price: params[:cart][:total_price],
-      shipping_to: params[:cart][:address_id]
+      last_name: @address.last_name,
+      first_name: @address.first_name,
+      postcode: @address.postcode,
+      prefecture_code: @address.prefecture_code,
+      address_city: @address.address_city,
+      address_street: @address.address_street,
+      address_building: @address.address_building,
+      phone_number: @address.phone_number,
     )
 
     @carts.each do |item|

--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -14,7 +14,7 @@ class CartsController < ApplicationController
   end
 
   def pay
-    @address = @user.addresses.first
+    @address = current_user.addresses.find(params[:cart][:address_id])
   end
 
   def complete
@@ -60,6 +60,10 @@ class CartsController < ApplicationController
     @carts = current_user.carts
     @user = current_user
     @addresses = @user.addresses
+  end
+
+  def cart_params
+    params.require(:cart).permit(:checkbox, address_id:[])
   end
 
 end

--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -14,7 +14,11 @@ class CartsController < ApplicationController
   end
 
   def pay
-    @address = current_user.addresses.find(params[:cart][:address_id])
+    if params[:cart].blank?
+      redirect_to carts_path, notice: "住所の登録/選択をお願いします"
+    else
+      @address = current_user.addresses.find(params[:cart][:address_id])
+    end
   end
 
   def complete

--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -16,8 +16,11 @@ class CartsController < ApplicationController
   def pay
     if params[:cart].blank?
       redirect_to carts_path, notice: "住所の登録/選択をお願いします"
+    elsif params[:cart][:address_ids].count > 1
+      redirect_to carts_path, notice: "住所は一つしか選択できません。"
     else
-      @address = current_user.addresses.find(params[:cart][:address_id])
+      @address = current_user.addresses.find(params[:cart][:address_ids])
+      @address = @address.first
     end
   end
 
@@ -65,7 +68,7 @@ class CartsController < ApplicationController
   end
 
   def cart_params
-    params.require(:cart).permit(:address_id)
+    params.require(:cart).permit(address_ids:[])
   end
 
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -5,5 +5,6 @@ class OrdersController < ApplicationController
 
   def show
     @order = Order.find(params[:id])
+    @address = Address.find(@order.shipping_to)
   end
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -5,6 +5,5 @@ class OrdersController < ApplicationController
 
   def show
     @order = Order.find(params[:id])
-    @address = Address.find(@order.shipping_to)
   end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -53,13 +53,13 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   # If you have extra params to permit, append them to the sanitizer.
   def configure_sign_up_params
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:username, :points, :birthday,
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:id, :username, :points, :birthday,
       :height, :weight, :bust, :waist, :hip,
       addresses_attributes: [
       :first_name,
       :last_name,
       :postcode,
-      :prefecture_name,
+      :prefecture_code,
       :address_city,
       :address_street,
       :address_building,
@@ -71,13 +71,13 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   # If you have extra params to permit, append them to the sanitizer.
   def configure_account_update_params
-    devise_parameter_sanitizer.permit(:account_update, keys: [:username, :points, :birthday,
+    devise_parameter_sanitizer.permit(:account_update, keys: [:id, :username, :points, :birthday,
       :height, :weight, :bust, :waist, :hip,
       addresses_attributes: [
       :first_name,
       :last_name,
       :postcode,
-      :prefecture_name,
+      :prefecture_code,
       :address_city,
       :address_street,
       :address_building,

--- a/app/views/carts/index.html.erb
+++ b/app/views/carts/index.html.erb
@@ -71,7 +71,7 @@
           </tr>
           <tr>
             <th></th>
-            <td><%= f.check_box :address_id ,{}, address.id, false %>
+            <td><%= f.check_box :address_ids ,{multiple: true}, address.id, false %>
                 この住所を今回のお届け先に指定する</td>
           </tr>
         </table><hr>

--- a/app/views/carts/index.html.erb
+++ b/app/views/carts/index.html.erb
@@ -1,75 +1,83 @@
 <article>
+  <% if @carts.empty? %>
+    <%= link_to '商品を追加する', clothes_path %><hr>
+  <% else %>
 
-  <h3>Items in your cart!</h3><br>
+    <%= form_with(model: @carts, local: true, url: cart_pay_path(@carts.ids) ) do |f| %>
+      <h3>Items in your cart!</h3><br>
+      <% total_price = 0 %>
+      <% @carts.each do |item| %>
+        <div class="row">
+          <% @clothe = item.stock.clothe %>
+          <div class="offset-md-1 col-md-3">
+            <%= image_tag @clothe.images.first.variant(resize: "180x180") if @clothe.images.attached? %>
+          </div>
 
-  <%= link_to '他の商品を追加する', clothes_path %><hr>
+          <div class="col-md-5">
+            <table>
+              <tr>
+                <th class="col-md-5">ブランド名</th>
+                <td class="col-md-7"><%= @clothe.retailer.name %></td>
+              </tr>
+              <tr>
+                <th class="col-md-5">アイテム</th>
+                <td class="col-md-7"><%= @clothe.name %></td>
+              </tr>
+              <tr>
+                <th class="col-md-5">サイズ</th>
+                <td class="col-md-7"><%= item.stock.size %></td>
+              </tr>
+              <tr>
+                <th class="col-md-5">カラー</th>
+                <td class="col-md-7"><%= item.stock.color %></td>
+              </tr>
+              <tr>
+                <th class="col-md-5">金額</th>
+                <td class="col-md-7"><%= @clothe.price %>円（税込み）</td>
+                <% total_price += @clothe.price %>
+              </tr>
+            </table>
+          </div>
+          <div class="col-md-3">
+            <br><br><br>
+            <%= link_to 'カートから削除', cart_path(id: item.id), method: :delete %>
+          </div>
+        </div><hr>
+      <% end %>
 
-  <% total_price = 0 %>
-  <% @carts.each do |item| %>
-    <div class="row">
-      <% @clothe = item.stock.clothe %>
-      <div class="offset-md-1 col-md-3">
-        <%= image_tag @clothe.images.first.variant(resize: "180x180") if @clothe.images.attached? %>
-      </div>
+      <p style="text-align:center;">合計金額：<%= total_price %> 円（税込み）</p><br>
 
-      <div class="col-md-5">
+      <hr><h4>お届け先情報</h4>
+
+      <% n = 0 %>
+      <% @addresses.each do |address| %>
+        <hr><h5>お届け先情報 <%= n += 1 %> </h5><hr>
         <table>
           <tr>
-            <th class="col-md-5">ブランド名</th>
-            <td class="col-md-7"><%= @clothe.retailer.name %></td>
+            <th>お名前：</th>
+            <td><%= address.last_name %><%= address.first_name %></td>
           </tr>
           <tr>
-            <th class="col-md-5">アイテム</th>
-            <td class="col-md-7"><%= @clothe.name %></td>
+            <th>郵便番号：</th>
+            <td><%= address.postcode %></td>
           </tr>
           <tr>
-            <th class="col-md-5">サイズ</th>
-            <td class="col-md-7"><%= item.stock.size %></td>
+            <th>住所：</th>
+            <% pref = JpPrefecture::Prefecture.find(address.prefecture_code) %>
+            <td><%= pref.name if address.prefecture_code %> <%= address.address_city %>
+              <%= address.address_street %> <%= address.address_building %></td>
           </tr>
           <tr>
-            <th class="col-md-5">カラー</th>
-            <td class="col-md-7"><%= item.stock.color %></td>
+            <th></th>
+            <td><%= f.check_box :address_id ,{}, address.id, false %>
+                この住所を今回のお届け先に指定する</td>
           </tr>
-          <tr>
-            <th class="col-md-5">金額</th>
-            <td class="col-md-7"><%= @clothe.price %>円（税込み）</td>
-            <% total_price += @clothe.price %>
-          </tr>
-        </table>
-      </div>
-      <div class="col-md-3">
-        <br><br><br>
-        <%= link_to 'カートから削除', cart_path(id: item.id), method: :delete %>
-      </div>
-    </div><hr>
+        </table><hr>
+      <% end %>
+      <%= link_to 'お届け先を追加/変更する', edit_user_registration_path %><br><br>
+
+      <%# <%= link_to '購入へすすむ', cart_pay_path(@carts.ids)  if @carts.present? %>
+      <h5><%= f.submit '購入へすすむ' %></h5><br>
+    <% end %>
   <% end %>
-
-  <p style="text-align:center;">合計金額：<%= total_price %> 円（税込み）</p><br>
-
-  <hr><h4>お届け先情報</h4>
-
-  <% n = 0 %>
-  <% @addresses.each do |address| %>
-    <hr><h5>お届け先情報 <%= n += 1 %> </h5><hr>
-    <table>
-      <tr>
-        <th>お名前：</th>
-        <td><%= address.last_name %><%= address.first_name %></td>
-      </tr>
-      <tr>
-        <th>郵便番号：</th>
-        <td><%= address.postcode %></td>
-      </tr>
-      <tr>
-        <th>住所：</th>
-        <% pref = JpPrefecture::Prefecture.find(address.prefecture_code) %>
-        <td><%= pref.name if address.prefecture_code %> <%= address.address_city %>
-          <%= address.address_street %> <%= address.address_building %></td>
-      </tr>
-    </table><hr>
-  <% end %>
-  <%= link_to 'お届け先を追加/変更する', edit_user_registration_path %><br><br>
-
-  <h5><%= link_to '購入へすすむ', cart_pay_path(@carts.ids) if @carts.present? %></h5><br>
-
 </article>

--- a/app/views/carts/index.html.erb
+++ b/app/views/carts/index.html.erb
@@ -1,6 +1,8 @@
 <article>
+  <hr><h3>カート</h3><hr>
   <% if @carts.empty? %>
-    <%= link_to '商品を追加する', clothes_path %><hr>
+    <p>カートに商品を追加すると内容が表示されます！</p>
+    <%= link_to '商品を追加する', clothes_path, class: "btn btn-info" %><hr>
   <% else %>
 
     <%= form_with(model: @carts, local: true, url: cart_pay_path(@carts.ids) ) do |f| %>

--- a/app/views/carts/pay.html.erb
+++ b/app/views/carts/pay.html.erb
@@ -69,6 +69,7 @@
     </script>
 
   <%= f.hidden_field :total_price, value: total_price %>
+  <%= f.hidden_field :address_id, value: @address.id %>
   <% end %>
 
   <hr>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -8,7 +8,6 @@
         <th>ご注文日</th>
         <th>合計</th>
         <th>詳細</th>
-        <th>レビュー</th>
       </tr>
       <% @orders.each do |order| %>
         <tr>
@@ -16,7 +15,6 @@
           <td><%= l order.created_at %></td>
           <td>¥<%= order.price %></td>
           <td><%= link_to '注文の詳細', order_path(order.id) %></td>
-          <td><%= link_to 'レビューを書いてポイントGet' %></td>
         </tr>
       <% end %>
     </table>

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -1,10 +1,7 @@
 <article>
   <hr><h3>ご注文の詳細</h3><hr><br>
 
-  <strong><p>ご注文日：<%= l @order.created_at %><p></strong>
-  <% shipping_info = current_user.addresses.first %><hr>
-  <%# <% shipping_info = current_user.addresses.find(order.shipping_to) %>
-
+  <strong><p>ご注文日：<%= l @order.created_at %><p></strong><hr>
 
   <% @order.bought_stocks.each do |stock| %>
     <% @clothe = stock.clothe %>
@@ -49,20 +46,20 @@
   <table>
     <tr>
       <th>お名前：</th>
-      <td><%= shipping_info.last_name %><%= shipping_info.first_name %></td>
+      <td><%= @address.last_name %><%= @address.first_name %></td>
     </tr>
     <tr>
       <th>郵便番号：</th>
-      <td><%= shipping_info.postcode %></td>
+      <td><%= @address.postcode %></td>
     </tr>
     <tr>
       <th>住所：</th>
-      <% pref = JpPrefecture::Prefecture.find(shipping_info.prefecture_code) %>
-      <td><%= pref.name %><%= shipping_info.address_city %><%= shipping_info.address_street %><%= shipping_info.address_building %></td>
+      <% pref = JpPrefecture::Prefecture.find(@address.prefecture_code) %>
+      <td><%= pref.name %><%= @address.address_city %><%= @address.address_street %><%= @address.address_building %></td>
     </tr>
     <tr>
       <th>お電話番号：</th>
-      <td><%= shipping_info.phone_number %></td>
+      <td><%= @address.phone_number %></td>
     </tr>
   </table><br><br>
 

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -46,20 +46,20 @@
   <table>
     <tr>
       <th>お名前：</th>
-      <td><%= @address.last_name %><%= @address.first_name %></td>
+      <td><%= @order.last_name %><%= @order.first_name %></td>
     </tr>
     <tr>
       <th>郵便番号：</th>
-      <td><%= @address.postcode %></td>
+      <td><%= @order.postcode %></td>
     </tr>
     <tr>
       <th>住所：</th>
-      <% pref = JpPrefecture::Prefecture.find(@address.prefecture_code) %>
-      <td><%= pref.name %><%= @address.address_city %><%= @address.address_street %><%= @address.address_building %></td>
+      <% pref = JpPrefecture::Prefecture.find(@order.prefecture_code) %>
+      <td><%= pref.name %><%= @order.address_city %><%= @order.address_street %><%= @order.address_building %></td>
     </tr>
     <tr>
       <th>お電話番号：</th>
-      <td><%= @address.phone_number %></td>
+      <td><%= @order.phone_number %></td>
     </tr>
   </table><br><br>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,6 +46,7 @@ Rails.application.routes.draw do
   end
 
   resources :carts, only: %i[ create destroy index update ] do
+    post :pay
     get :pay
     post :complete
   end

--- a/db/migrate/20210810040928_change_columns_in_orders.rb
+++ b/db/migrate/20210810040928_change_columns_in_orders.rb
@@ -1,0 +1,13 @@
+class ChangeColumnsInOrders < ActiveRecord::Migration[5.2]
+  def change
+    add_column :orders, :last_name, :string, null: false, default: ""
+    add_column :orders, :first_name, :string, null: false, default: ""
+    add_column :orders, :postcode, :integer, null: false, default: 0
+    add_column :orders, :prefecture_code, :integer, null: false, default: 0
+    add_column :orders, :address_city, :string, null: false, default: ""
+    add_column :orders, :address_street, :string, null: false, default: ""
+    add_column :orders, :address_building, :string
+    add_column :orders, :phone_number, :string, null: false, default: ""
+    remove_column :orders, :shipping_to, :integer, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_08_123845) do
+ActiveRecord::Schema.define(version: 2021_08_10_040928) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -129,7 +129,14 @@ ActiveRecord::Schema.define(version: 2021_08_08_123845) do
     t.integer "price", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "shipping_to", default: 1, null: false
+    t.string "last_name", default: "", null: false
+    t.string "first_name", default: "", null: false
+    t.integer "postcode", default: 0, null: false
+    t.integer "prefecture_code", default: 0, null: false
+    t.string "address_city", default: "", null: false
+    t.string "address_street", default: "", null: false
+    t.string "address_building"
+    t.string "phone_number", default: "", null: false
     t.index ["user_id"], name: "index_orders_on_user_id"
   end
 


### PR DESCRIPTION
close #48 

- [x] 住所を選択できるようにview, controllerで設定

- [x] 住所が登録・選択されていない時、レンダーさせるように設定
- [x] 住所が複数選択されている時、レンダーして一つだけ選ぶように指示 
- [x] orders tableに住所カラムを追加（users.addressを参照だと、登録内容が変更された時にordersの内容も変わってしまうため）
